### PR TITLE
Fixed thread URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Smashboards-CSM
-Smashboards Community Symbol Map for Melee. Topic: http://smashboards.com/threads/smashboards-community-symbol-map/
+Smashboards Community Symbol Map for Melee. Topic: http://smashboards.com/threads/smashboards-community-symbol-map.426763/
 
 Hey! I'm Absolome and this is the Smashboards Community Symbol Map. In short, it's a project attempting to combine the knowlege of modders and tinkerers of Super Smash Brothers Melee. 
 


### PR DESCRIPTION
The thread URL was broken since it lacked the thread ID.
